### PR TITLE
Swap foreach and reduce

### DIFF
--- a/R/MCrow.R
+++ b/R/MCrow.R
@@ -3,7 +3,7 @@
 #' This function simulates MC step for a single row. Should not need to be used by user directly.
 #'
 #' @author Bryan Martin
-#' 
+#'
 #' @param Yi row of logratio matrix
 #' @param Wi corresponding row of count matrix
 #' @param eYi current expected value of logratio matrix
@@ -17,11 +17,22 @@
 MCrow <- function(Yi, Wi, eYi, Q, base, sigInv, MCiter, stepsize = 1) {
   # extra column for acceptance indicator
   Yi.MH <- matrix(0, MCiter, Q)
-  
-  
+
+  # Precompute all the normal dist. vals we will need.
+  norm_vals <- matrix(
+    rnorm((Q - 1) * MCiter, 0, stepsize),
+    ncol = MCiter
+  )
+
+  # Precompute all uniform dist. vals we will need.
+  unif_vals <- runif(MCiter)
+
   for (i in 1:MCiter) {
     # cat(i,'\n') proposal
-    Yi.star <- Yi + rnorm(Q - 1, 0, stepsize)
+
+    # Access normal dist. vals by column for speed.
+    Yi.star <- Yi + norm_vals[, i]
+
     # denominator
     Eq5pt1 <- sum(Wi) * (log(sum(exp(Yi)) + 1) - log(sum(exp(Yi.star)) + 1))
     # numerator
@@ -30,7 +41,7 @@ MCrow <- function(Yi, Wi, eYi, Q, base, sigInv, MCiter, stepsize = 1) {
     Eq5pt4 <- -0.5 * crossprod((Yi - eYi), sigInv) %*% (Yi - eYi)
     fullRat <- Eq5pt1 + Eq5pt2 + Eq5pt3 - Eq5pt4
     acceptance <- min(1, exp(fullRat))
-    temp <- runif(1)
+    temp <- unif_vals[[i]]
     aVal <- 0
     if (temp < acceptance | is.nan(acceptance)) {
       Yi <- Yi.star
@@ -39,7 +50,7 @@ MCrow <- function(Yi, Wi, eYi, Q, base, sigInv, MCiter, stepsize = 1) {
     # each row is a resampling of Yi, first col is whether accepted or not
     Yi.MH[i, ] <- c(aVal, Yi)
   }
-  
+
   ## returns a matrix Yi.MH: MH samples of row, first column ind if accepted (MCiter rows, Q cols)
   return(Yi.MH)
 }

--- a/R/fit_aitchison.R
+++ b/R/fit_aitchison.R
@@ -145,7 +145,7 @@ fit_aitchison <- function(W,
     sigSumFun <- function(i) {
       return(crossprod(t(MCarray[i, 2:Q, 1:N]) - eY))
     }
-    sigSum <- foreach(i = (MCburn + 1):MCiter, .combine = "+") %do% sigSumFun(i)
+    sigSum <- Reduce(`+`, lapply((MCburn + 1):MCiter, sigSumFun))
     sigma <- sigSum/(N * (MCiter - MCburn))
     
     # update b


### PR DESCRIPTION
So I was doing some profiling of the code (due to issue #28) and one of the things I found was swapping the `foreach() ... %do%` with `Reduce ... lapply` gave a pretty noticeable speedup.

## Tests

The dataset I tested on was `lee_phylum` from the [Getting Started vignette](https://github.com/adw96/DivNet/blob/master/vignettes/getting-started.Rmd).

For the original, I got the following runtimes: 

- 67.97s
- 49.73s
- 65.99s
- 34.78s

For the shorter runtime, it didn't hit the garbage collector, but for the other ones it did.

For the Reduce version:

- 25.38s
- 25.48s
- 57s

For the longer runtime it hit the garbage collector, but for the other ones it did not.

Not sure exactly why the Reduce lapply version is faster than the foreach %do%, but it may have to do with the foreach %do% way hitting the GC more often.  But the reduce version is also faster even when neither hit the GC.

 (Also worth noting that the Docker container I'm running on has only 2 GB of ram.)

## Profiles

Here is some of the output from the profiling runs that I did using `profvis`.

[profiles.zip](https://github.com/adw96/DivNet/files/3383527/profiles.zip)
