### PR TITLE
Fix usage comment

### DIFF
--- a/R/MCmat.R
+++ b/R/MCmat.R
@@ -1,15 +1,15 @@
 #' MCmat
 #'
-#' This function simulates MC step for an entire matrix. Should not need to be used by user directly; available to help with determining network estimation. 
+#' This function simulates MC step for an entire matrix. Should not need to be used by user directly; available to help with determining network estimation.
 #'
 #' @author Bryan Martin
 #' @author Amy Willis
-#' 
+#'
 #' @param Y logratio matrix
 #' @param W corresponding count matrix
 #' @param eY current expected value of logratio matrix
 #' @param N number of samples, or nrow of Y
-#' @param Q number of OTUs minus the base, or ncol of Y
+#' @param Q number of OTUs, or ncol of W
 #' @param base OTU index used for base
 #' @param sigma current estimate of sigma
 #' @param MCiter number of MC samples to generate
@@ -18,22 +18,22 @@
 #' @param network How to estimate network. Defaults to "default" (generalised inverse, aka naive). Other options include "diagonal", or a function that takes a sample covariance matrix and returns an estimate of the inverse covariance matrix (eg glasso or SpiecEasi)
 #' @param ncores number of cores to use, defaults to 1
 #' @param ... additional arguments to be supplied to the network function
-#' 
+#'
 #' @import doParallel
 #' @import abind
 #' @import foreach
 #'
 #' @export
-MCmat <- function(Y, W, eY, N, Q, base, sigma, MCiter, stepsize = 1, 
+MCmat <- function(Y, W, eY, N, Q, base, sigma, MCiter, stepsize = 1,
                   perturbation = 0.05, network = "default", ncores = 1, ...) {
-  
+
   if (network == "diagonal") {
     sigInv <- diagonal_network(sigma)
   } else if (network == "default") {
     sigInv <- default_network(sigma)
   } else if (network == "stars") {
     sigInv <- stars(sigma, W, base = base, perturbation = perturbation, ncores = ncores, ...)
-  } else { 
+  } else {
     sigInv <- try(network(sigma, ...), silent = T)
     if (class(sigInv) == "try-error") {
       stop("Cannot use supplied network option?")
@@ -42,13 +42,13 @@ MCmat <- function(Y, W, eY, N, Q, base, sigma, MCiter, stepsize = 1,
   # Global variables check fix
   i <- NULL
   MH_path <- function(i) {
-    MCrow(Yi = Y[i, ], Wi = W[i, ], eYi = eY[i, ], Q = Q, base = base, sigInv = sigInv, MCiter = MCiter, 
+    MCrow(Yi = Y[i, ], Wi = W[i, ], eYi = eY[i, ], Q = Q, base = base, sigInv = sigInv, MCiter = MCiter,
           stepsize = stepsize)
   }
-  
+
   if (ncores > 1 & requireNamespace("doParallel", quietly = TRUE) &
       requireNamespace("foreach", quietly = TRUE) &
-      requireNamespace("doSNOW", quietly = TRUE) 
+      requireNamespace("doSNOW", quietly = TRUE)
   ) {
     ####################
     # Parallel option ##
@@ -69,7 +69,7 @@ MCmat <- function(Y, W, eY, N, Q, base, sigma, MCiter, stepsize = 1,
       MH_path(i)
     }
   }
-  
+
   # Should be (MCiter x Q x N) Dont forget, first column is acceptance
   return(Y.MH)
 }
@@ -98,17 +98,17 @@ default_network <- function(sigma) {
 }
 
 #' stars
-#' 
+#'
 #' @param sigma current estimate of sigma
 #' @param W corresponding count matrix
 #' @param base OTU index used for base
 #' @param perturbation size of purturbation used for to_log_ratios, defaults to 0.05
 #' @param ncores number of cores to use, defaults to 1
 #' @param ... other arguments to pass
-#' 
+#'
 #' Estimate the network using the package SpiecEasi
 stars <- function(sigma, W, base, perturbation, ncores, ...) {
-  
+
   if (!requireNamespace("glasso", quietly = TRUE) | !requireNamespace("SpiecEasi", quietly = TRUE)) {
     stop("Packages glasso and SpiecEasi are needed for this function to work. \n
          Please install them.",

--- a/R/MCrow.R
+++ b/R/MCrow.R
@@ -7,7 +7,7 @@
 #' @param Yi row of logratio matrix
 #' @param Wi corresponding row of count matrix
 #' @param eYi current expected value of logratio matrix
-#' @param Q number of OTUs minus the base, or length of Yi
+#' @param Q number of OTUs, or length of Wi
 #' @param base OTU index used for base
 #' @param sigInv current estimate of sigma inverse
 #' @param MCiter number of MC samples to generate


### PR DESCRIPTION
While going through the functions, I noticed that the usage comments in the `MCrow` and `MCmat` functions for parameter `Q` seem to be incorrect.

`Q` is set in `fit_aitchison()` here: https://github.com/adw96/DivNet/blob/2c37e61462b2a4bc0c77a6080cf6166d86159e92/R/fit_aitchison.R#L30

before being passed into `MCrow()`, and that's the number of OTUs.

It's also being used as the number of OTUs in the `MCrow` function.

(Sorry about the extra changes in the `MCmat.R` function.  My text editor deleting the trailing spaces in a bunch of the lines.)