### PR TITLE
Comment out testing on ubuntu-20.04 r-devel because bioconductor seem…

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -25,8 +25,9 @@ jobs:
           - {os: windows-latest, r: 'release'}
           - {os: macOS-latest, r: 'release'}
           - {os: ubuntu-20.04, r: 'release', rspm: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest"}
-          - {os: ubuntu-20.04, r: 'devel', rspm: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest"}
-
+  #        - {os: ubuntu-20.04, r: 'devel', rspm: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest"}
+  # PAULINE FLAG: Current open issue with r-devel: Bioconductor does not yet build and check packages for R version 4.2
+  # ISSUE#471: https://github.com/r-hub/rhub/issues/471
     env:
       R_REMOTES_NO_ERRORS_FROM_WARNINGS: true
       RSPM: ${{ matrix.config.rspm }}


### PR DESCRIPTION
…s unable to build and check packegs for R4.2. Open issue linked on this known issue. Need to go back and build in this testing in the future once resolved.