### PR TITLE
adding warning for non-standard characters in sample names

### DIFF
--- a/R/beta_diversity_helper.R
+++ b/R/beta_diversity_helper.R
@@ -20,6 +20,13 @@ simplifyBeta <- function(dv,
   
   Covar2 <- Covar1 <- beta_est <- beta_var <- Sample2 <- Sample1 <- NULL
   
+  in_sample_names <- physeq %>% sample_names
+  changed_sample_names <- dv[[measure]] %>% data.frame %>% names
+  
+  if ( ! all(in_sample_names == changed_sample_names) ) {
+    stop("Your sample names contain non-standard characters, please change that :)")
+  }
+  
   beta_var_matrix <- dv[[paste(measure, "-variance", sep = "")]]
   
   vars <- physeq %>% sample_data %>% get_variable(x) 


### PR DESCRIPTION
Addressing issue #73 by adding a warning against using special characters in sample names (proposed by Mike in #62 as an alternate solution to turning off check.names in data.frame, which we're concerned could cause unexpected problems in other places). 