### PR TITLE
Removing all references to `master` branch 

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -19,7 +19,7 @@ knitr::opts_chunk$set(
 
 <!-- badges: start -->
   [![R-CMD-check](https://github.com/adw96/DivNet/workflows/R-CMD-check/badge.svg)](https://github.com/adw96/DivNet/actions)
-  [![codecov.io](https://codecov.io/gh/adw96/DivNet/coverage.svg?branch=master)](https://codecov.io/gh/adw96/DivNet?branch=main)
+  [![codecov.io](https://codecov.io/gh/adw96/DivNet/coverage.svg?branch=main)](https://codecov.io/gh/adw96/DivNet?branch=main)
   <!-- badges: end -->
 
 DivNet: an R package to estimate diversity when taxa in the community cooccur via a ecological network.
@@ -32,7 +32,7 @@ If you knew the exact composition of a community (such as all of the microbes li
 
 Almost all ecologists use "plug-in" diversity estimates, obtained by taking the observed relative abundances of each taxon and plugging them into the formula for the true diversity. This is problematic for a number of reasons, including that there may be unobserved taxa, and the observed relative abundances probably don't exactly equal the true relative abundances due to random sampling. Furthermore, typical approaches to obtaining a confidence interval assume that all taxa behave independently: if taxon A is there, this tells you nothing about whether taxon B is likely to be there too. DivNet takes care of all of these issues, and gives you a confidence interval that incorporates all of these challenges.
 
-See [the vignette](https://github.com/adw96/DivNet/blob/master/vignettes/getting-started.Rmd) for a full tutorial, and [the paper](https://academic.oup.com/biostatistics/advance-article-abstract/doi/10.1093/biostatistics/kxaa015/5841114) for more details.
+See [the vignette](https://github.com/adw96/DivNet/blob/main/vignettes/getting-started.Rmd) for a full tutorial, and [the paper](https://academic.oup.com/biostatistics/advance-article-abstract/doi/10.1093/biostatistics/kxaa015/5841114) for more details.
 
 Want a confidence interval for a different diversity index? Let us know by posting an [issue](https://github.com/adw96/DivNet/issues)!
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 <!-- badges: start -->
 
-[![R-CMD-check](https://github.com/adw96/DivNet/workflows/R-CMD-check/badge.svg)](https://github.com/adw96/DivNet/actions) [![codecov.io](https://codecov.io/gh/adw96/DivNet/coverage.svg?branch=master)](https://codecov.io/gh/adw96/DivNet?branch=main) <!-- badges: end -->
+[![R-CMD-check](https://github.com/adw96/DivNet/workflows/R-CMD-check/badge.svg)](https://github.com/adw96/DivNet/actions) [![codecov.io](https://codecov.io/gh/adw96/DivNet/coverage.svg?branch=main)](https://codecov.io/gh/adw96/DivNet?branch=main) <!-- badges: end -->
 
 DivNet: an R package to estimate diversity when taxa in the community cooccur via a ecological network.
 
@@ -16,7 +16,7 @@ If you knew the exact composition of a community (such as all of the microbes li
 
 Almost all ecologists use “plug-in” diversity estimates, obtained by taking the observed relative abundances of each taxon and plugging them into the formula for the true diversity. This is problematic for a number of reasons, including that there may be unobserved taxa, and the observed relative abundances probably don’t exactly equal the true relative abundances due to random sampling. Furthermore, typical approaches to obtaining a confidence interval assume that all taxa behave independently: if taxon A is there, this tells you nothing about whether taxon B is likely to be there too. DivNet takes care of all of these issues, and gives you a confidence interval that incorporates all of these challenges.
 
-See [the vignette](https://github.com/adw96/DivNet/blob/master/vignettes/getting-started.Rmd) for a full tutorial, and [the paper](https://academic.oup.com/biostatistics/advance-article-abstract/doi/10.1093/biostatistics/kxaa015/5841114) for more details.
+See [the vignette](https://github.com/adw96/DivNet/blob/main/vignettes/getting-started.Rmd) for a full tutorial, and [the paper](https://academic.oup.com/biostatistics/advance-article-abstract/doi/10.1093/biostatistics/kxaa015/5841114) for more details.
 
 Want a confidence interval for a different diversity index? Let us know by posting an [issue](https://github.com/adw96/DivNet/issues)!
 

--- a/vignettes/README.md
+++ b/vignettes/README.md
@@ -2,4 +2,4 @@ Currently we have a detailed vignettes about DivNet and how to use it on phylose
 
 We plan to make more vignettes as we better understand what users of DivNet are likely to need. Feel free to log a feature request under Issues if there is something you would like to see but don't.
 
-[Here](https://github.com/adw96/stamps2018/blob/master/estimation/diversity-lab.R) you will find an interactive tutorial on diversity estimation using [breakaway](https://github.com/adw96/breakaway) and [DivNet](https://github.com/adw96/DivNet).
+[Here](https://github.com/adw96/stamps2018/blob/main/estimation/diversity-lab.R) you will find an interactive tutorial on diversity estimation using [breakaway](https://github.com/adw96/breakaway) and [DivNet](https://github.com/adw96/DivNet).


### PR DESCRIPTION
Replacing `master` with `main` in README files 