### PR TITLE
patching a bug related to testBetaDiversity, switching sapply to lapply

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: DivNet
 Type: Package
 Title: Diversity Estimation in Networked Ecological Communities
-Version: 0.4.0
+Version: 0.4.1
 Authors@R: c(person("Amy", "Willis", email = "adwillis@uw.edu", role = c("aut", "cre")), person("Bryan D", "Martin", email = "bmartin6@uw.edu", role = c("aut")))
 Description: Estimate alpha- and beta- diversity of a community where taxa interact.
 License: GPL (>= 2)
@@ -39,5 +39,5 @@ Suggests:
 Additional_repositories: https://github.com/mikemc/speedyseq
 Encoding: UTF-8
 LazyData: true
-RoxygenNote: 7.1.2
+RoxygenNote: 7.3.2
 VignetteBuilder: knitr

--- a/R/s3functions.R
+++ b/R/s3functions.R
@@ -122,7 +122,7 @@ testBetaDiversity <- function(dv,
   unique_groups <- unique(groups)
   unique_specimens <- colnames(sample_specimen_matrix)
   n_specimens <- ncol(sample_specimen_matrix)
-  group_specimens <- sapply(unique_groups,
+  group_specimens <- lapply(unique_groups,
                             function(x) apply(sample_specimen_matrix[groups == x,],2,max) %>%
                               (function(y) names(y)[y==1]))
 
@@ -167,7 +167,7 @@ if(h0 == "bray-curtis"){
 
     comps <- dv$fitted_z[which_samples,]
 
-    boot_group_specimens <-sapply(unique_groups,
+    boot_group_specimens <-lapply(unique_groups,
            function(x) apply(sample_specimen_matrix[groups == x,np_boot_pulls[,k]],2,max) %>%
              (function(y) names(y)[y==1]))
 
@@ -244,7 +244,7 @@ if(h0 == "euclidean"){
 
     comps <- dv$fitted_z[which_samples,]
 
-    boot_group_specimens <-sapply(unique_groups,
+    boot_group_specimens <-lapply(unique_groups,
                                   function(x) apply(sample_specimen_matrix[groups == x,np_boot_pulls[,k]],2,max) %>%
                                     (function(y) names(y)[y==1]))
 
@@ -317,7 +317,7 @@ if(h0 == "aitchison"){
 
     comps <- log_ratio(dv$fitted_z[which_samples,])
 
-    boot_group_specimens <-sapply(unique_groups,
+    boot_group_specimens <-lapply(unique_groups,
                                   function(x) apply(sample_specimen_matrix[groups == x,np_boot_pulls[,k]],2,max) %>%
                                     (function(y) names(y)[y==1]))
 

--- a/R/utility.R
+++ b/R/utility.R
@@ -51,7 +51,7 @@ acomb3 <- function(...) abind(..., along = 3)
 #' @param automatic_cutoff Choose detection cutoff automatically? Default is 
 #' FALSE. If TRUE, detection_cutoff will be set equal to the maximum proportion
 #' of samples any taxon is detected in.
-#' @value Index corresponding to taxon chosen as base taxon
+#' @return Index corresponding to taxon chosen as base taxon
 #' @author Amy Willis
 #' @export
 pick_base <- function(W,

--- a/man/pick_base.Rd
+++ b/man/pick_base.Rd
@@ -17,6 +17,9 @@ unless automatic_cutoff is set to TRUE.}
 FALSE. If TRUE, detection_cutoff will be set equal to the maximum proportion
 of samples any taxon is detected in.}
 }
+\value{
+Index corresponding to taxon chosen as base taxon
+}
 \description{
 Picks the base taxon to be used in divnet fit. If no taxon is detected
 in all samples, returns error; in this case, we recommend manually choosing 

--- a/tests/testthat/test_s3.R
+++ b/tests/testthat/test_s3.R
@@ -36,6 +36,27 @@ test_that("beta diversity hypothesis testing works for bray-curtis", {
                               n_boot = 10), "list")
 })
 
+test_that("beta diversity hypothesis testing works with two even groups", {
+  Lee_even <- Lee_subset %>%
+    phyloseq::subset_samples(sample_id %in% c(3:4, 6:9, 15:16))
+  divnet_phylum_even <-   divnet(Lee_even,
+                                   X = "sample_id", tuning = "test")
+  ss_mat_even = diag(nrow(sample_data(Lee_even)))
+  colnames(ss_mat_even) <- sample_data(Lee_even)$sample_id
+  expect_is(testBetaDiversity(dv = divnet_phylum_even, h0 = "bray-curtis",
+                              groups = sample_data(Lee_even)$char,
+                              sample_specimen_matrix = ss_mat_even,
+                              n_boot = 10), "list")
+  expect_is(testBetaDiversity(dv = divnet_phylum_even, h0 = "euclidean",
+                              groups = sample_data(Lee_even)$char,
+                              sample_specimen_matrix = ss_mat_even,
+                              n_boot = 10), "list")
+  expect_is(testBetaDiversity(dv = divnet_phylum_even, h0 = "aitchison",
+                              groups = sample_data(Lee_even)$char,
+                              sample_specimen_matrix = ss_mat_even,
+                              n_boot = 10), "list")
+})
+
 test_that("beta diversity hypothesis testing works for euclidean", {
   expect_is(testBetaDiversity(dv = divnet_phylum_sample, h0 = "euclidean",
                               groups = sample_data(Lee_subset)$char,


### PR DESCRIPTION
Addressing issue #146, which describes an issue with `testBetaDiversity()` when there are equal groups of samples in each covariate level. This is addressed by switching several calls of `sapply` to `lapply`, and tests are included to evaluate this fix. The version number is incremented to reflect this patch. 