### PR TITLE
Fix off-by-1 indexing bug (#154)

### DIFF
--- a/R/fit_aitchison.R
+++ b/R/fit_aitchison.R
@@ -174,7 +174,7 @@ fit_aitchison <- function(W,
   cat("\n")
   
   ## Next: take average of EM samples past burn. Included init, so have EMiter+1 total 
-  b0_EM <- colMeans(b0_list[(EMburn + 1):(EMiter + 1), ])
+  b0_EM <- colMeans(b0_list[(EMburn + 2):(EMiter + 1), ])
   
   output_list$beta0 <- b0_EM
   
@@ -182,7 +182,7 @@ fit_aitchison <- function(W,
   if (no_covariates) {
     fitted_y <- matrix(b0_EM, ncol = Q-1, nrow = N, byrow=T)
   } else {
-    b_list_reduced <- b_list[, , (EMburn + 1):(EMiter + 1)] 
+    b_list_reduced <- b_list[, , (EMburn + 2):(EMiter + 1)] 
     
     if (length(dim(b_list_reduced)) == 2) {
       b_list_reduced <- b_list_reduced %>% array(c(1, dim(b_list_reduced)))
@@ -196,7 +196,7 @@ fit_aitchison <- function(W,
   }
   
   # burn-in sigma and take average; fine b/c class of positive def matrices is closed under addition
-  sigma_em <- apply(sigma_list[, , (EMburn + 1):(EMiter + 1)], c(1, 2), mean)
+  sigma_em <- apply(sigma_list[, , (EMburn + 2):(EMiter + 1)], c(1, 2), mean)
   
   # store parameters
   output_list$sigma <- sigma_em


### PR DESCRIPTION
Take EMburn = 3, and EMiter = 6. Originally, we're indexing from (3+1):(6+1) -> 4:7 -> c(4, 5, 6, 7). The first item is the init value. The next three c(2, 3, 4) are in the burn section, and the final three c(5, 6, 7) are in the keep section. However, we're pulling in the final one in the burn section.  So it should be EMburn + 2.

See https://github.com/adw96/DivNet/issues/154.

---

I assume the actual numerical difference made by this change would be small. To do a quick check of that I ran through the debugger using this data:

```R
data(Lee)
Lee_phylum <- phyloseq::tax_glom(Lee, taxrank="Phylum")
divnet_phylum_char <- divnet(Lee_phylum, X = "char", tuning = "test")
```

Then added some diagnostic plots to the fit_atichison function. Something like this:

b0_EM:

```R
  b0_EM <- colMeans(b0_list[(EMburn + 2):(EMiter + 1), ])

  b0_EM_old <- colMeans(b0_list[(EMburn + 1):(EMiter + 1), ])
  plot(b0_EM, b0_EM_old)
  abline(a = 0, b = 1)
```  

<img width="433" height="450" alt="b0_EM" src="https://github.com/user-attachments/assets/9e4009bf-edc4-42a0-8e39-8d7afa6b22b3" />


b_EM:

```R
    b_list_reduced <- b_list[,, (EMburn + 2):(EMiter + 1)]

    b_list_reduced_old <- b_list[,, (EMburn + 1):(EMiter + 1)]

    if (length(dim(b_list_reduced)) == 2) {
      b_list_reduced <- b_list_reduced %>% array(c(1, dim(b_list_reduced)))
      b_list_reduced_old <- b_list_reduced_old %>%
        array(c(1, dim(b_list_reduced_old)))
    }

    b_EM <- apply(b_list_reduced, c(1, 2), mean)
    b_EM_old <- apply(b_list_reduced_old, c(1, 2), mean)
    output_list$beta <- b_EM

    plot(as.vector(b_EM), as.vector(b_EM_old))
    abline(a = 0, b = 1)
```

<img width="433" height="450" alt="b_EM" src="https://github.com/user-attachments/assets/444f1937-d143-4f9d-a815-b65fc1627f1e" />


sigma_em: 

```R
  sigma_em <- apply(sigma_list[,, (EMburn + 2):(EMiter + 1)], c(1, 2), mean)

  sigma_em_old <- apply(sigma_list[,, (EMburn + 1):(EMiter + 1)], c(1, 2), mean)
  plot(as.vector(sigma_em), as.vector(sigma_em_old))
  abline(a = 0, b = 1)
```

<img width="433" height="450" alt="sigma_em" src="https://github.com/user-attachments/assets/45d6b693-1333-45f7-aa59-1af2562999cc" />

(If you look at the actual values there very close.)